### PR TITLE
Create action to automatically build and test code

### DIFF
--- a/.github/workflowsbuild_and_test.yml
+++ b/.github/workflowsbuild_and_test.yml
@@ -1,0 +1,38 @@
+name: Python package
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8
+          if [ -f requirements.txt ]; then pip install -e .; fi
+      - name: Lint with flake8
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          # Skip linting errors that we need to make the code formatting readable
+          flake8 *.py --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --ignore=E221,E222,E225,E231,E301
+      - name: Test with pytest
+        run: |
+          python -m unittest discover -s test


### PR DESCRIPTION
This is a test action which runs on pushes and pull-requests and builds and tests the python code. Currently only does a few "smoke tests" for the `FortranDriver` module. Qt GUI Fortran backend testing is TBD.