### PR TITLE
Update unit tests to run on MacOS VM

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: [ubuntu-latest, macos-latest]
     strategy:
       matrix:
         python-version: [3.9]


### PR DESCRIPTION
A lot of our users are on Mac, so having unit tests which run on Mac would be useful to catch strange MacOS-specific behaviour.